### PR TITLE
Fix email confirmation link pointing to localhost

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -30,10 +30,12 @@ export async function POST(request: NextRequest) {
     }
 
     // Sign up via Supabase Auth — the trigger creates the profile row
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? request.nextUrl.origin;
     const { data, error } = await supabase.auth.signUp({
       email,
       password,
       options: {
+        emailRedirectTo: `${siteUrl}/auth/callback`,
         data: {
           display_name: displayName,
           zip_code: zipCode,

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,19 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = request.nextUrl;
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/";
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/signin?error=email_confirmation_failed`);
+}


### PR DESCRIPTION
## Summary

- Passes `emailRedirectTo` to `supabase.auth.signUp()` so confirmation emails link to the correct host instead of `localhost:3000`
- The redirect URL is derived from `NEXT_PUBLIC_SITE_URL` env var if set, otherwise falls back to the request's own origin (works correctly in dev and production automatically)
- Adds `/auth/callback` route to exchange the one-time `code` from the confirmation link for a real session

## Root cause

`supabase.auth.signUp()` in `/api/auth/signup/route.ts` had no `emailRedirectTo` option, so Supabase fell back to its default redirect URL — which defaults to `localhost:3000` unless explicitly overridden in the Supabase dashboard.

## Test plan

- [ ] Sign up with a new email
- [ ] Click the confirmation link in the email — should redirect to the app (not localhost)
- [ ] Confirm you are logged in after the redirect
- [ ] Set `NEXT_PUBLIC_SITE_URL` in production env and verify it takes precedence

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)